### PR TITLE
0.2.1 - fix file extension and filter docx files in file picker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,4 +43,14 @@
         "editor.tabSize": 2,
     },
     "python.testing.unittestEnabled": false,
+    "cSpell.words": [
+        "cicd",
+        "initialfile",
+        "insertbackground",
+        "mypy",
+        "pady",
+        "pytest",
+        "roteiro",
+        "Subclip"
+    ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### changed
 ### removed
 
+- typing improvements
 - spellchecking
 
 ### changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### changed
 - code refactor
 
+### removed
+- setup to allow changing separator for final file
+
 ## 0.2.0
 2024/01/06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### changed
 ### removed
 
+- spellchecking
+
 ### changed
 - code refactor
 
@@ -39,7 +41,7 @@
 - versioning
 - tk gui
 - flake8 linting gh actions
-- black formating gh actions
+- black formatting gh actions
 - test badge on readme
 
 ### changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### changed
 ### removed
 
+### added
+- file picker now only shows .docx files
 - typing improvements
 - spellchecking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@
 ### changed
 ### removed
 
+## 0.2.1
+2024/01/09
+
 ### added
 - file picker now only shows .docx files
+- develop branch
 - typing improvements
 - spellchecking
 
 ### changed
+- changed final file extension to csv, still tab separated
 - code refactor
 
 ### removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### changed
 ### removed
 
+### changed
+- code refactor
+
 ## 0.2.0
 2024/01/06
 

--- a/src/__version__.py
+++ b/src/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.0"
+VERSION = "0.2.1"

--- a/src/roteiro.py
+++ b/src/roteiro.py
@@ -73,7 +73,6 @@ def format_timedelta(delta: timedelta) -> str:
 
 
 def format_line(name: str, start: str, duration: str, description: str) -> str:
-    sep = ","
     sep = "\t"
 
     time_format = "decimal"

--- a/src/roteiro.py
+++ b/src/roteiro.py
@@ -24,9 +24,12 @@ def extract_lines(filename: str) -> list[str]:
     return lines
 
 
+def extract_timestamp_or_none(
+    string: str,
+) -> tuple[str, str, str | None] | None:
     m = re.match(ROTEIRO_TIMESTAMP_FORMAT, string)
     if not m:
-        raise ValueError()
+        return None
 
     matches = m.groupdict()
 
@@ -90,13 +93,12 @@ def get_markers(filename):
 
     values = []
     for line in lines:
-        try:
-            timestamp = extract_timestamp(line)
-        except ValueError:
-            timestamp = None
+        timestamp = extract_timestamp_or_none(line)
 
-        if timestamp:
-            start, description, end = timestamp
+        if timestamp is None:
+            continue
+
+        start, description, end = timestamp
 
             name, start_time, duration, description = format_timestamp(
                 start, description, end

--- a/src/roteiro.py
+++ b/src/roteiro.py
@@ -139,7 +139,12 @@ def gui(markers_strategy: Callable):
     fg_color = "white"
 
     def _pick_file():
-        filename = filedialog.askopenfilename()
+        filename = filedialog.askopenfilename(
+            filetypes=(("docx", "*.docx"),),
+        )
+
+        if not filename:  # user hit 'cancel' or closed dialog
+            return
 
         markers = markers_strategy(filename)
 

--- a/src/roteiro.py
+++ b/src/roteiro.py
@@ -42,7 +42,7 @@ def extract_timestamp_or_none(
 
 
 def format_timestamp(
-    start: str, description: str, end: str
+    start: str, description: str, end: str | None
 ) -> tuple[str, timedelta, timedelta, str]:
     name = start
 
@@ -88,7 +88,7 @@ def format_line(name: str, start: str, duration: str, description: str) -> str:
     )
 
 
-def get_markers(filename):
+def get_markers(filename: str) -> list[str]:
     lines = extract_lines(filename)
 
     values = []
@@ -135,7 +135,7 @@ def cli(markers_strategy: Callable):
     return 0
 
 
-def gui(markers_strategy: Callable, version: str):
+def gui(markers_strategy: Callable):
     bg_color = "#2E2E2E"
     fg_color = "white"
 

--- a/src/roteiro.py
+++ b/src/roteiro.py
@@ -100,16 +100,16 @@ def get_markers(filename):
 
         start, description, end = timestamp
 
-            name, start_time, duration, description = format_timestamp(
-                start, description, end
-            )
-            formated_line = format_line(
-                name,
-                format_timedelta(start_time),
-                format_timedelta(duration),
-                description,
-            )
-            values.append(formated_line)
+        name, start_time, duration, description = format_timestamp(
+            start, description, end
+        )
+        formatted_line = format_line(
+            name,
+            format_timedelta(start_time),
+            format_timedelta(duration),
+            description,
+        )
+        values.append(formatted_line)
 
     return values
 

--- a/src/roteiro.py
+++ b/src/roteiro.py
@@ -158,12 +158,14 @@ def gui(markers_strategy: Callable):
         root.clipboard_append(all_text)
         root.update()
 
-    def _save_tsv():
+    # for some reason adobe audition requires a tab separated value file with
+    # a .csv extension
+    def _save_csv():
         f = filedialog.asksaveasfile(
             mode="w",
-            defaultextension=".tsv",
+            defaultextension=".csv",
             initialfile="Markers",
-            filetypes=(("tsv", "*.tsv"),),
+            filetypes=(("csv", "*.csv"),),
         )
 
         if not f:  # user hit 'cancel' or closed dialog
@@ -210,8 +212,8 @@ def gui(markers_strategy: Callable):
     # save button
     save_button = tk.Button(
         root,
-        text="Save .tsv",
-        command=_save_tsv,
+        text="Save .csv",
+        command=_save_csv,
         bg=bg_color,
         fg=fg_color,
     )

--- a/tests/test_roteiro.py
+++ b/tests/test_roteiro.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from src.roteiro import (
     extract_lines,
-    extract_timestamp,
+    extract_timestamp_or_none,
     format_line,
     format_timedelta,
     format_timestamp,
@@ -22,7 +22,7 @@ def test_extract_lines():
 
 
 def test_extract_timestamp():
-    assert extract_timestamp("0848	Description	1006") == (
+    assert extract_timestamp_or_none("0848	Description	1006") == (
         "0848",
         "Description",
         "1006",
@@ -30,11 +30,15 @@ def test_extract_timestamp():
 
 
 def test_extract_timestamp_optional_duration():
-    assert extract_timestamp("0848	Description") == (
+    assert extract_timestamp_or_none("0848	Description") == (
         "0848",
         "Description",
         None,
     )
+
+
+def test_extract_timestamp_no_valid_timestamp():
+    assert extract_timestamp_or_none("Not a valid timestamp") is None
 
 
 def test_format_timestamp():


### PR DESCRIPTION
## 0.2.1
2024/01/09

### added
- file picker now only shows .docx files
- develop branch
- typing improvements
- spellchecking

### changed
- changed final file extension to csv, still tab separated
- code refactor

### removed
- setup to allow changing separator for final file
